### PR TITLE
Feat/receiver json rote

### DIFF
--- a/src/application/operations/email/sendEmailCreatePassword.ts
+++ b/src/application/operations/email/sendEmailCreatePassword.ts
@@ -1,9 +1,14 @@
+import { SystemContextException } from "../../../domain/exceptions/SystemContextException";
 import { NodemailerEmailSender } from "../../../infrastructure/email/nodeMailerEmailSender";
 import { EmailUseCase } from "../../use-cases/email/EmailUseCase";
 
 export function sendEmailCreatePassword(email: string, name: string) {
-    const emailSender = NodemailerEmailSender.getInstance();
-    const emailUseCase = new EmailUseCase(emailSender);
+    try {
+        const emailSender = NodemailerEmailSender.getInstance();
+        const emailUseCase = new EmailUseCase(emailSender);
 
-    emailUseCase.sendEmailToCreatePassword(email, name, email);
+        emailUseCase.sendEmailToCreatePassword(email, name, email);
+    } catch (error) {
+        throw new SystemContextException('Erro ao enviar email');
+    }
 }

--- a/src/application/use-cases/auth/RegisterUseCase.ts
+++ b/src/application/use-cases/auth/RegisterUseCase.ts
@@ -30,7 +30,7 @@ export class RegisterUseCase {
             name: userData.getName(),
             email: userData.getEmail(),
             cpf: userData.getCpf(),
-            role: 'FUNCIONARIO',
+            role: userData.getRole(),
             active: false
         });
 

--- a/src/application/use-cases/measure/ReadMeasureUseCase.ts
+++ b/src/application/use-cases/measure/ReadMeasureUseCase.ts
@@ -1,5 +1,4 @@
 import { IMeasureRepository } from "../../../domain/interfaces/repositories/IMeasureRepository";
-import { Measure } from "../../../domain/models/agregates/Measure/Measure";
 import { MeasureUseCase } from "./MeasureUseCase";
 import { ReadMeasureResponseDTO } from "../../../web/dtos/measure/ReadMeasureDTO";
 

--- a/src/application/use-cases/measure/RegisterMeasureUseCase.ts
+++ b/src/application/use-cases/measure/RegisterMeasureUseCase.ts
@@ -12,6 +12,7 @@ export class RegisterMeasureUseCase extends MeasureUseCase {
 
   constructor(measureRepository: IMeasureRepository, parameterRepository: IParameterRepository) {
     super(measureRepository);
+    this.parameterRepository = parameterRepository;
   }
 
   public async execute(data: RegisterMeasureDTO): Promise<Measure> {
@@ -26,8 +27,7 @@ export class RegisterMeasureUseCase extends MeasureUseCase {
     let value = data.value * typeParameter.factor + typeParameter.offset;
 
     const measure = Measure.create(data.unixTime, value);
-
-    await this.measureRepository.createMeasure(measure);
-    return measure;
+    measure.parameter = parameter;
+    return await this.measureRepository.createMeasure(measure);
   }
 }

--- a/src/application/use-cases/receiverJson/receiverJsonUseCase.ts
+++ b/src/application/use-cases/receiverJson/receiverJsonUseCase.ts
@@ -1,0 +1,71 @@
+import { SystemContextException } from "../../../domain/exceptions/SystemContextException";
+import { IAlertRepository } from "../../../domain/interfaces/repositories/IAlertRepository";
+import { IMeasureRepository } from "../../../domain/interfaces/repositories/IMeasureRepository";
+import { IParameterRepository } from "../../../domain/interfaces/repositories/IParameterRepository";
+import { IStationRepository } from "../../../domain/interfaces/repositories/IStationRepository";
+import { ITypeAlertRepository } from "../../../domain/interfaces/repositories/ITypeAlertRepository";
+import { RegisterAlertDTO } from "../../../web/dtos/alert/RegisterAlertDTO";
+import { RegisterMeasureDTO } from "../../../web/dtos/measure/RegisterMesureDTO";
+import RegisterAlertUseCase from "../alert/RegisterAlertUseCase";
+import { RegisterMeasureUseCase } from "../measure/RegisterMeasureUseCase";
+
+export default class ReceiverJsonUseCase {
+    constructor(
+        private stationRepository: IStationRepository,
+        private alertRepository: IAlertRepository,
+        private typeAlertRepository: ITypeAlertRepository,
+        private measureRepository: IMeasureRepository,
+        private parameterRepository: IParameterRepository
+    ) {}
+
+    async execute(dataJson: any) {
+        const { uid, unixtime, ...measurements } = dataJson;
+        if (!uid || !unixtime) {
+            throw new SystemContextException("Dados inválidos");
+        }
+
+        const station = await this.stationRepository.findByUuid(uid);
+        if (!station) {
+            throw new SystemContextException("Estação não encontrada");
+        }
+
+        const registerMeasureUseCase = new RegisterMeasureUseCase(this.measureRepository, this.parameterRepository);
+        const registerAlertUseCase = new RegisterAlertUseCase(this.alertRepository, this.typeAlertRepository, this.measureRepository);
+
+        for (const [key, value] of Object.entries(measurements)) {
+            const parameter = station.parameters.find(p => p.idTypeParameter.typeJson === key);
+            if (!parameter) {
+                throw new SystemContextException(`Tipo de dado não encontrado: ${key}`);
+            }
+
+            const measureData: RegisterMeasureDTO = {
+                unixTime: unixtime,
+                value: Number(value),
+                parameterId: parameter.id
+            };
+
+            const measure = await registerMeasureUseCase.execute(measureData);
+            if (measure?.value == null) continue;
+
+            for (const typeAlert of parameter.typeAlerts) {
+                if (this.shouldTriggerAlert(measure.value, typeAlert.comparisonOperator, typeAlert.value)) {
+                    const alertData: RegisterAlertDTO = {
+                        date: unixtime,
+                        typeAlerdId: typeAlert.id,
+                        measureId: measure.id
+                    };
+                    await registerAlertUseCase.execute(alertData);
+                }
+            }
+        }
+    }
+
+    private shouldTriggerAlert(measureValue: number, operator: string, threshold: number): boolean {
+        switch (operator) {
+            case "<": return measureValue < threshold;
+            case ">": return measureValue > threshold;
+            case "=": return measureValue === threshold;
+            default: return false;
+        }
+    }
+}

--- a/src/application/use-cases/user/UpdateUserUseCase.ts
+++ b/src/application/use-cases/user/UpdateUserUseCase.ts
@@ -36,6 +36,10 @@ export class UpdateUserUseCase {
             }
             updateData.cpf = userData.getCpf();
         }
+
+        if (userData.getRole()) {
+            updateData.role = userData.getRole();
+        }
         
         const updatedUser = await this.userRepository.update(userData.getId(), updateData);
         return transformUserToDTO(updatedUser);

--- a/src/domain/interfaces/repositories/IMeasureRepository.ts
+++ b/src/domain/interfaces/repositories/IMeasureRepository.ts
@@ -3,7 +3,7 @@ import { Measure } from "../../models/entities/Measure";
 
 
 export interface IMeasureRepository {
-  createMeasure(measure: Measure): Promise<Measure>;
+  createMeasure(measure: Partial<Measure>): Promise<Measure>;
   getById(id: string): Promise<Measure | null>;
   listMeasures(stationId: string): Promise<ListMeasureResponseDTO[]>;
   deleteMeasure(id: string): Promise<boolean>;

--- a/src/domain/models/entities/Measure.ts
+++ b/src/domain/models/entities/Measure.ts
@@ -1,18 +1,18 @@
-import { Column, Entity, ManyToOne, OneToMany, PrimaryColumn } from "typeorm";
+import { Column, Entity, ManyToOne, OneToMany, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
 import { Alert } from "../agregates/Alert/Alert";
 import Parameter from "../agregates/Parameter/Parameter";
 
 @Entity()
 export class Measure {
 
-    @PrimaryColumn("uuid")
+    @PrimaryGeneratedColumn("uuid")
     id: string;
     
-    @Column()
+    @Column({ type: "bigint" })
     unixTime: number;
 
-    @Column()
-    value: number;
+    @Column({ type: "float" }) 
+    value: number;    
 
     @OneToMany(() => Alert, alert => alert.measure)
     alerts: Alert[];    

--- a/src/infrastructure/repositories/AlertRepository.ts
+++ b/src/infrastructure/repositories/AlertRepository.ts
@@ -28,7 +28,6 @@ export class AlertRepository implements IAlertRepository {
           "measure.parameter.idStation",
         ],
       });
-      console.log(alert);
       
     } else {
       alert = await this.alerts.find({

--- a/src/infrastructure/repositories/MeasureRepository.ts
+++ b/src/infrastructure/repositories/MeasureRepository.ts
@@ -10,7 +10,7 @@ export class MeasureRepository implements IMeasureRepository {
   private measures: Repository<Measure> = AppDataSource.getRepository(Measure);
 
   // Método para criar um Measure
-  async createMeasure(measure: Measure): Promise<Measure> {
+  async createMeasure(measure: Partial<Measure>): Promise<Measure> {
     return await this.measures.save(measure);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { parameterRoutes } from './web/routes/parameter.routes';
 import { errorMiddleware } from './web/middlewares/errorMiddleware';
 import { alertRoutes } from './web/routes/Alert.routes';
 import { measureRoutes } from './web/routes/Measure.routes';
+import { receiverJsonRoutes } from './web/routes/receiverJson.routes';
 
 async function bootstrap() {
     try {
@@ -35,6 +36,7 @@ async function bootstrap() {
         app.use('/measure', measureRoutes);
         app.use('/alert', alertRoutes);
         app.use('/parameter', parameterRoutes);
+        app.use('/receiverJson', receiverJsonRoutes);
 
         // Middleware de erro deve ser o último
         app.use(errorMiddleware);

--- a/src/web/controllers/auth/RegisterController.ts
+++ b/src/web/controllers/auth/RegisterController.ts
@@ -7,13 +7,13 @@ export class RegisterController {
 
     async handle(request: Request, response, next: NextFunction): Promise<Response> {
         try {
-            const { name, email, cpf } = request.body;
+            const { name, email, cpf, role } = request.body;
 
-            if (!name || !email || !cpf) {
-                return response.sendError('Nome, email e CPF são obrigatórios', 400);
+            if (!name || !email || !cpf || !role) {
+                return response.sendError('Nome, email, CPF e função são obrigatórios', 400);
             }
 
-            const userData: RegisterUserDTO = new RegisterUserDTO(name, email, cpf);
+            const userData: RegisterUserDTO = new RegisterUserDTO(name, email, cpf, role);
 
             const readUser = await this.registerUseCase.execute(userData);
 

--- a/src/web/controllers/receiverJson/receiverJsonController.ts
+++ b/src/web/controllers/receiverJson/receiverJsonController.ts
@@ -1,0 +1,17 @@
+import { NextFunction, Request } from "express";
+import ReceiverJsonUseCase from "../../../application/use-cases/receiverJson/receiverJsonUseCase";
+
+export class ReceiverJsonController {
+    constructor(private receiverJsonUseCase: ReceiverJsonUseCase) {}
+
+    async handle(request: Request, response, next: NextFunction) {
+        try {
+            const dataJson = request.body;
+            await this.receiverJsonUseCase.execute(dataJson);
+            return response.sendSuccess("Dados cadastrados", 200);
+        }
+        catch (error) {
+            next(error);
+        }
+    }
+}

--- a/src/web/controllers/user/UpdateUserController.ts
+++ b/src/web/controllers/user/UpdateUserController.ts
@@ -7,13 +7,13 @@ export class UpdateUserController {
 
     async handle(request: Request, response, next: NextFunction): Promise<Response> {
         try {
-            const { id, name, email, cpf } = request.body;
+            const { id, name, email, cpf, role } = request.body;
 
             if (!id) {
                 return response.sendError('Usuário não encontrado ou inexistente', 400);
             }
 
-            const userData: UpdateUserDTO = new UpdateUserDTO(id, name, email, cpf);
+            const userData: UpdateUserDTO = new UpdateUserDTO(id, name, email, cpf, role);
 
             const user = await this.updateUserUseCase.execute(userData);
 

--- a/src/web/dtos/auth/RegisterUserDTO.ts
+++ b/src/web/dtos/auth/RegisterUserDTO.ts
@@ -2,11 +2,13 @@ export default class RegisterUserDTO {
     protected name: string;
     private email: string;
     private cpf: string;
+    private role: string;
 
-    constructor(name: string, email: string, cpf: string) {
+    constructor(name: string, email: string, cpf: string, role: string) {
         this.name = name;
         this.email = email;
         this.cpf = cpf;
+        this.role = role;
     }
 
     public getName(): string {
@@ -19,5 +21,9 @@ export default class RegisterUserDTO {
 
     public getCpf(): string {
         return this.cpf;
+    }
+
+    public getRole(): string {
+        return this.role;
     }
 }

--- a/src/web/dtos/auth/UpdateUserDTO.ts
+++ b/src/web/dtos/auth/UpdateUserDTO.ts
@@ -3,12 +3,14 @@ export class UpdateUserDTO {
     private name: string;
     private email: string;
     private cpf: string;
+    private role: string;
 
-    constructor(id: string, name: string, email: string, cpf: string) {
+    constructor(id: string, name: string, email: string, cpf: string, role: string) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.cpf = cpf;
+        this.role = role;
     }
 
     public getId(): string {
@@ -25,5 +27,9 @@ export class UpdateUserDTO {
 
     public getCpf(): string {
         return this.cpf;
+    }
+
+    public getRole(): string {
+        return this.role;
     }
 }

--- a/src/web/middlewares/errorMiddleware.ts
+++ b/src/web/middlewares/errorMiddleware.ts
@@ -16,7 +16,8 @@ export const errorMiddleware = (err: any, req: Request, res: Response, next: Nex
         return sendError("Não é possível excluir ou atualizar este item, pois ele está em uso.", 400);
       }
     }
-
+    
+    console.error(err);
     return sendError("Ocorreu um erro inesperado no servidor.", 500);
   }
 };

--- a/src/web/routes/Alert.routes.ts
+++ b/src/web/routes/Alert.routes.ts
@@ -38,10 +38,10 @@ const alertController = new AlertController(
 const alertRoutes = Router();
 
 // Routes
-alertRoutes.post('/create', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => alertController.create(req, res, next)));
-alertRoutes.put('/update', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => alertController.update(req, res, next)));
-alertRoutes.get('/list', limiter, ensureAuthenticated, asyncHandler((req, res, next) => alertController.getAll(req, res, next)));
-alertRoutes.get('/read/:id', limiter, ensureAuthenticated, asyncHandler((req, res, next) => alertController.getById(req, res, next)));
+alertRoutes.post('/create', limiter, ensureAuthenticated, asyncHandler((req, res, next) => alertController.create(req, res, next)));
+alertRoutes.put('/update', limiter, ensureAuthenticated, asyncHandler((req, res, next) => alertController.update(req, res, next)));
+alertRoutes.get('/list', limiter, asyncHandler((req, res, next) => alertController.getAll(req, res, next)));
+alertRoutes.get('/read/:id', limiter, asyncHandler((req, res, next) => alertController.getById(req, res, next)));
 alertRoutes.delete('/delete/:id', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => alertController.delete(req, res, next)));
 
 export { alertRoutes };

--- a/src/web/routes/Measure.routes.ts
+++ b/src/web/routes/Measure.routes.ts
@@ -37,8 +37,8 @@ const measureRoutes = Router();
 // Routes
 measureRoutes.post('/create', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => measureController.create(req, res, next)));
 measureRoutes.put('/update', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => measureController.update(req, res, next)));
-measureRoutes.get('/list', limiter, ensureAuthenticated, asyncHandler((req, res, next) => measureController.getAll(req, res, next)));
-measureRoutes.get('/read/:id', limiter, ensureAuthenticated, asyncHandler((req, res, next) => measureController.getById(req, res, next)));
+measureRoutes.get('/list', limiter, asyncHandler((req, res, next) => measureController.getAll(req, res, next)));
+measureRoutes.get('/read/:id', limiter, asyncHandler((req, res, next) => measureController.getById(req, res, next)));
 measureRoutes.delete('/delete/:id', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => measureController.delete(req, res, next)));
 
 export { measureRoutes };

--- a/src/web/routes/parameter.routes.ts
+++ b/src/web/routes/parameter.routes.ts
@@ -11,6 +11,7 @@ import { UpdateParameterController } from "../controllers/parameter/UpdateParame
 import DeleteParameterUseCase from "../../application/use-cases/parameter/DeleteParameterUseCase";
 import { DeleteParameterController } from "../controllers/parameter/DeleteParameterController";
 import { asyncHandler } from "../middlewares/asyncHandler";
+import { ensureAuthenticatedAdmin } from "../../infrastructure/middlewares/ensureAuthenticatedAdmin";
 
 const parameterRoutes = Router();
 const parameterRepository = new ParameterRepository();
@@ -35,10 +36,11 @@ const deleteController = new DeleteParameterController(deleteParameterUseCase);
 
 // Routes
 parameterRoutes.post('/create', limiter, ensureAuthenticated, asyncHandler((req, res, next) => createController.handle(req, res, next)));
-parameterRoutes.get('/list', limiter, ensureAuthenticated, asyncHandler((req, res, next) => listController.handle(req, res, next)));
+
+parameterRoutes.get('/list', limiter, asyncHandler((req, res, next) => listController.handle(req, res, next)));
 
 parameterRoutes.put('/update', limiter, ensureAuthenticated, asyncHandler((req, res, next) => updateController.handle(req, res, next)));
 
-parameterRoutes.delete('/delete/:id', limiter, ensureAuthenticated, asyncHandler((req, res, next) => deleteController.handle(req, res, next)));
+parameterRoutes.delete('/delete/:id', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => deleteController.handle(req, res, next)));
 
 export { parameterRoutes }

--- a/src/web/routes/receiverJson.routes.ts
+++ b/src/web/routes/receiverJson.routes.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import ReceiverJsonUseCase from "../../application/use-cases/receiverJson/receiverJsonUseCase";
+import { AlertRepository } from "../../infrastructure/repositories/AlertRepository";
+import { MeasureRepository } from "../../infrastructure/repositories/MeasureRepository";
+import StationRepository from "../../infrastructure/repositories/StationRepository";
+import TypeAlertRepository from "../../infrastructure/repositories/TypeAlertRepository";
+import { ReceiverJsonController } from "../controllers/receiverJsonController";
+import { asyncHandler } from "../middlewares/asyncHandler";
+import { ParameterRepository } from "../../infrastructure/repositories/ParameterRepository";
+
+const measureRepository = new MeasureRepository();
+const stationRepository = new StationRepository();
+const alertRepository = new AlertRepository();
+const typeAlertRepository = new TypeAlertRepository();
+const parameterRepository = new ParameterRepository();
+
+const receiverJsonUseCase = new ReceiverJsonUseCase(
+    stationRepository,
+    alertRepository,
+    typeAlertRepository,
+    measureRepository,
+    parameterRepository
+)
+
+const receiverJsonController = new ReceiverJsonController(receiverJsonUseCase);
+
+const receiverJsonRoutes = Router();
+
+receiverJsonRoutes.post('/', asyncHandler((req, res, next) => receiverJsonController.handle(req, res, next)));
+
+export { receiverJsonRoutes };

--- a/src/web/routes/receiverJson.routes.ts
+++ b/src/web/routes/receiverJson.routes.ts
@@ -7,6 +7,8 @@ import TypeAlertRepository from "../../infrastructure/repositories/TypeAlertRepo
 import { asyncHandler } from "../middlewares/asyncHandler";
 import { ParameterRepository } from "../../infrastructure/repositories/ParameterRepository";
 import { ReceiverJsonController } from "../controllers/receiverJson/receiverJsonController";
+import { limiter } from "../../infrastructure/middlewares/limiter";
+import { ensureAuthenticated } from "../../infrastructure/middlewares/ensureAuthenticated";
 
 const measureRepository = new MeasureRepository();
 const stationRepository = new StationRepository();
@@ -26,6 +28,6 @@ const receiverJsonController = new ReceiverJsonController(receiverJsonUseCase);
 
 const receiverJsonRoutes = Router();
 
-receiverJsonRoutes.post('/', asyncHandler((req, res, next) => receiverJsonController.handle(req, res, next)));
+receiverJsonRoutes.post('/', limiter, ensureAuthenticated, asyncHandler((req, res, next) => receiverJsonController.handle(req, res, next)));
 
 export { receiverJsonRoutes };

--- a/src/web/routes/receiverJson.routes.ts
+++ b/src/web/routes/receiverJson.routes.ts
@@ -4,9 +4,9 @@ import { AlertRepository } from "../../infrastructure/repositories/AlertReposito
 import { MeasureRepository } from "../../infrastructure/repositories/MeasureRepository";
 import StationRepository from "../../infrastructure/repositories/StationRepository";
 import TypeAlertRepository from "../../infrastructure/repositories/TypeAlertRepository";
-import { ReceiverJsonController } from "../controllers/receiverJsonController";
 import { asyncHandler } from "../middlewares/asyncHandler";
 import { ParameterRepository } from "../../infrastructure/repositories/ParameterRepository";
+import { ReceiverJsonController } from "../controllers/receiverJson/receiverJsonController";
 
 const measureRepository = new MeasureRepository();
 const stationRepository = new StationRepository();

--- a/src/web/routes/station.routes.ts
+++ b/src/web/routes/station.routes.ts
@@ -38,14 +38,14 @@ const listController = new ListStationController(listStationUseCase);
 const readStationUseCase = new ReadStationUseCase(stationRepository);
 const readController = new ReadStationController(readStationUseCase);
 
-stationRoutes.post('/create', limiter, asyncHandler((req, res, next) => createController.handle(req, res, next)));
+stationRoutes.post('/create', limiter, ensureAuthenticated, asyncHandler((req, res, next) => createController.handle(req, res, next)));
 
 stationRoutes.put('/update', limiter, ensureAuthenticated, asyncHandler((req, res, next) => updateController.handle(req, res, next)));
 
 stationRoutes.delete('/delete/:id', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => deleteController.handle(req, res, next)));
 
-stationRoutes.get('/list', limiter, ensureAuthenticated, asyncHandler((req, res, next) => listController.handle(req, res, next)));
+stationRoutes.get('/list', limiter, asyncHandler((req, res, next) => listController.handle(req, res, next)));
 
-stationRoutes.get('/read/:id', limiter, ensureAuthenticated, asyncHandler((req, res, next) => readController.handle(req, res, next)));
+stationRoutes.get('/read/:id', limiter, asyncHandler((req, res, next) => readController.handle(req, res, next)));
 
 export { stationRoutes }

--- a/src/web/routes/typeAlert.routes.ts
+++ b/src/web/routes/typeAlert.routes.ts
@@ -35,14 +35,14 @@ const typeAlertController = new TypeAlertController(
 typeAlertRoutes.post(
     "/",
     limiter,
-    ensureAuthenticatedAdmin,
+    ensureAuthenticated,
     asyncHandler((req, res, next) => typeAlertController.create(req, res, next))
 );
 
 typeAlertRoutes.put(
     "/",
     limiter,
-    ensureAuthenticatedAdmin,
+    ensureAuthenticated,
     asyncHandler((req, res, next) => typeAlertController.update(req, res, next))
 );
 
@@ -55,7 +55,6 @@ typeAlertRoutes.get(
 typeAlertRoutes.get(
     "/:id",
     limiter,
-    ensureAuthenticated,
     asyncHandler((req, res, next) => typeAlertController.getById(req, res, next))
 );
 

--- a/src/web/routes/typeParameter.routes.ts
+++ b/src/web/routes/typeParameter.routes.ts
@@ -13,6 +13,7 @@ import { ListTypeParameterController } from "../controllers/typeParameter/ListTy
 import { limiter } from "../../infrastructure/middlewares/limiter";
 import { ensureAuthenticated } from "../../infrastructure/middlewares/ensureAuthenticated";
 import { asyncHandler } from "../middlewares/asyncHandler";
+import { ensureAuthenticatedAdmin } from "../../infrastructure/middlewares/ensureAuthenticatedAdmin";
 
 const typeParameterRoutes = Router();
 const typeParametersRepository = new TypeParemeterRepository();
@@ -42,10 +43,10 @@ typeParameterRoutes.post('/create', limiter, ensureAuthenticated, asyncHandler((
 
 typeParameterRoutes.put('/update', limiter, ensureAuthenticated, asyncHandler((req, res, next) => updateController.handle(req, res, next)));
 
-typeParameterRoutes.delete('/delete/:id', limiter, ensureAuthenticated, asyncHandler((req, res, next) => deleteController.handle(req, res, next)));
+typeParameterRoutes.delete('/delete/:id', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => deleteController.handle(req, res, next)));
 
-typeParameterRoutes.get('/read/:id', limiter, ensureAuthenticated, asyncHandler((req, res, next) => readController.handle(req, res, next)));
+typeParameterRoutes.get('/read/:id', limiter, asyncHandler((req, res, next) => readController.handle(req, res, next)));
 
-typeParameterRoutes.get('/list', limiter, ensureAuthenticated, asyncHandler((req, res, next) => listController.handle(req, res, next)));
+typeParameterRoutes.get('/list', limiter, asyncHandler((req, res, next) => listController.handle(req, res, next)));
 
 export { typeParameterRoutes }

--- a/src/web/routes/user.routes.ts
+++ b/src/web/routes/user.routes.ts
@@ -39,7 +39,7 @@ const readController = new ReadUserController(readUserUseCase);
 const changePasswordUseCase = new ChangePasswordUseCase(userRepository);
 const changePasswordController = new ChangePasswordController(changePasswordUseCase);
 
-userRoutes.put('/update', limiter, ensureAuthenticated, asyncHandler((req, res, next) => updateController.handle(req, res, next)));
+userRoutes.put('/update', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => updateController.handle(req, res, next)));
 
 userRoutes.delete('/delete/:id', limiter, ensureAuthenticatedAdmin, asyncHandler((req, res, next) => deleteController.handle(req, res, next)));
 


### PR DESCRIPTION
## Branch
- feat/receiver-json-rote

## Changelog:
- Criei um usecase para poder receber um JSON com os parâmetros da estação
- verifica e cria alertas se existir um tipo alerta
- deixei rotas de create-update com permissão de funcionário
- deixei rotas de get e list com permissão geral
- deixei rotas de delete com permissão apenas para o admin
- agora você consegue definir o role do usuário ao criar e editar 

## Como Testar:
![image](https://github.com/user-attachments/assets/028ad915-780c-49b0-a034-272a35cdac5f)
passa o UUID da estação
os tipos de parametros que vai adicionar
e o unixtime

## Dependências:
- npm i