### PR TITLE
feat/A20-125/Criar-endpoint-para-retornar-os-dados

### DIFF
--- a/src/application/use-cases/dashboard/ListDashboardUseCase.ts
+++ b/src/application/use-cases/dashboard/ListDashboardUseCase.ts
@@ -1,0 +1,137 @@
+import { IMeasureRepository } from "../../../domain/interfaces/repositories/IMeasureRepository";
+import { IStationRepository } from "../../../domain/interfaces/repositories/IStationRepository";
+import { IParameterRepository } from "../../../domain/interfaces/repositories/IParameterRepository";
+import { Measure } from "../../../domain/models/entities/Measure";
+
+interface DashboardFilters {
+  startDate?: Date;
+  endDate?: Date;
+  stationId?: string;
+  parameterId?: string;
+}
+
+export class ListDashboardUseCase {
+  constructor(
+    private measurementRepository: IMeasureRepository,
+    private stationRepository: IStationRepository,
+    private parameterRepository: IParameterRepository
+  ) {}
+
+  async execute(filters: DashboardFilters = {}) {
+    try {
+      // Get all measurements matching the filters
+      const measurements = await this.measurementRepository.listWithFilters({
+        startDate: filters.startDate,
+        endDate: filters.endDate,
+        stationId: filters.stationId,
+        parameterId: filters.parameterId
+      });
+
+      // Get stations based on filter or all stations
+      const stations = filters.stationId 
+        ? [await this.stationRepository.findById(filters.stationId)]
+        : await this.stationRepository.list();
+      
+      // Get parameters with their relationships
+      const parameters = await Promise.all(
+        (await this.parameterRepository.list()).map(async p => {
+          return await this.parameterRepository.getWithParameterThenInclude(p.id);
+        })
+      ).then(params => params.filter(p => p !== null));
+      
+      // Group measurements by parameter ID
+      const measurementsByParameter = new Map();
+      
+      for (const measurement of measurements) {
+        if (!measurement.parameter || !measurement.parameter.id) {
+          continue;
+        }
+        
+        const parameterId = measurement.parameter.id;
+        
+        if (!measurementsByParameter.has(parameterId)) {
+          measurementsByParameter.set(parameterId, []);
+        }
+        
+        measurementsByParameter.get(parameterId).push({
+          id: measurement.id,
+          value: measurement.value,
+          timestamp: new Date(measurement.unixTime * 1000).toISOString()
+        });
+      }
+      
+      // Organize data by station
+      const stationsWithData = stations.map(station => {
+        // Get parameters for this station
+        const stationParameters = parameters.filter(p => 
+          p.idStation && p.idStation.id === station.id
+        );
+        
+        // For each parameter, add its type and measurements
+        const parametersWithDetails = stationParameters.map(param => {
+          // Get type parameter information
+          const typeParam = param.idTypeParameter;
+          
+          // Get measurements for this parameter
+          const measurementsForParameter = measurementsByParameter.get(param.id) || [];
+          
+          return {
+            id: param.id,
+            name: typeParam ? typeParam.name : "Unknown Parameter",
+            type: typeParam ? {
+              id: typeParam.id,
+              name: typeParam.name,
+              unit: typeParam.unit,
+              factor: typeParam.factor,
+              offset: typeParam.offset,
+              decimalCases: typeParam.numberOfDecimalsCases
+            } : null,
+            measurements: measurementsForParameter
+          };
+        });
+        
+        return {
+          id: station.id,
+          name: station.name,
+          location: {
+            latitude: station.latitude,
+            longitude: station.longitude
+          },
+          parameters: parametersWithDetails
+        };
+      });
+      
+      return {
+        stations: stationsWithData,
+        timeRange: {
+          start: this.getMinDate(measurements),
+          end: this.getMaxDate(measurements)
+        }
+      };
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  private getMinDate(measurements: Measure[]): Date | null {
+    if (!measurements || measurements.length === 0) {
+      return null;
+    }
+    const timestamps = measurements
+      .map(m => m.unixTime)
+      .filter(t => t !== undefined && t !== null);
+    
+    return timestamps.length > 0 ? new Date(Math.min(...timestamps) * 1000) : null;
+  }
+
+  private getMaxDate(measurements: Measure[]): Date | null {
+    if (!measurements || measurements.length === 0) {
+      return null;
+    }
+    const timestamps = measurements
+      .map(m => m.unixTime)
+      .filter(t => t !== undefined && t !== null);
+    
+    return timestamps.length > 0 ? new Date(Math.max(...timestamps) * 1000) : null;
+  }
+}

--- a/src/domain/interfaces/repositories/IMeasureRepository.ts
+++ b/src/domain/interfaces/repositories/IMeasureRepository.ts
@@ -8,4 +8,10 @@ export interface IMeasureRepository {
   listMeasures(stationId: string): Promise<ListMeasureResponseDTO[]>;
   deleteMeasure(id: string): Promise<boolean>;
   updateMeasure(measure: Measure): Promise<Measure>;
+  listWithFilters(filters: {
+    startDate?: Date;
+    endDate?: Date;
+    stationId?: string;
+    parameterId?: string;
+  }): Promise<Measure[]>;
 }

--- a/src/domain/interfaces/repositories/IParameterRepository.ts
+++ b/src/domain/interfaces/repositories/IParameterRepository.ts
@@ -1,13 +1,13 @@
-import ListParameterDTO from "../../../web/dtos/parameter/ListParameterDTO";
 import Parameter from "../../models/agregates/Parameter/Parameter";
+import ListParameterDTO from "../../../web/dtos/parameter/ListParameterDTO";
 
 export interface IParameterRepository {
-    create(parameter: Partial<Parameter>): Promise<Parameter>;
-    delete(id: string): Promise<boolean>;
-    update(id: string, parameter: Partial<Parameter>): Promise<Parameter>;
-    list(): Promise<Parameter[]>;  
-    getWithParameterThenInclude(id: string): Promise<Parameter | null>;
-    listDTO(): Promise<ListParameterDTO[]>;
     findById(id: string): Promise<Parameter | null>;
+    list(): Promise<Parameter[]>;
+    create(parameter: Partial<Parameter>): Promise<Parameter>;
+    update(id: string, parameter: Partial<Parameter>): Promise<Parameter | null>;
+    delete(id: string): Promise<boolean>;
+    listDTO(): Promise<ListParameterDTO[]>;
+    getWithParameterThenInclude(id: string): Promise<Parameter | null>;
 }
 

--- a/src/infrastructure/repositories/MeasureRepository.ts
+++ b/src/infrastructure/repositories/MeasureRepository.ts
@@ -9,6 +9,32 @@ import { param } from "express-validator";
 export class MeasureRepository implements IMeasureRepository {
   private measures: Repository<Measure> = AppDataSource.getRepository(Measure);
 
+  async listWithFilters(filters: { startDate?: Date; endDate?: Date; stationId?: string; parameterId?: string; }): Promise<Measure[]> {
+    const queryBuilder = this.measures.createQueryBuilder('measure')
+      .leftJoinAndSelect('measure.parameter', 'parameter'); // Important: Load the parameter relationship
+    
+    if (filters.startDate) {
+      const startUnixTime = Math.floor(filters.startDate.getTime() / 1000);
+      queryBuilder.andWhere('measure.unixTime >= :startUnixTime', { startUnixTime });
+    }
+    
+    if (filters.endDate) {
+      const endUnixTime = Math.floor(filters.endDate.getTime() / 1000);
+      queryBuilder.andWhere('measure.unixTime <= :endUnixTime', { endUnixTime });
+    }
+    
+    if (filters.parameterId) {
+      queryBuilder.andWhere('parameter.id = :parameterId', { parameterId: filters.parameterId });
+    }
+    
+    if (filters.stationId) {
+      queryBuilder.leftJoin('parameter.idStation', 'station')
+        .andWhere('station.id = :stationId', { stationId: filters.stationId });
+    }
+    
+    return await queryBuilder.getMany();
+  }
+
   // Método para criar um Measure
   async createMeasure(measure: Partial<Measure>): Promise<Measure> {
     return await this.measures.save(measure);

--- a/src/infrastructure/repositories/ParameterRepository.ts
+++ b/src/infrastructure/repositories/ParameterRepository.ts
@@ -10,7 +10,6 @@ export class ParameterRepository implements IParameterRepository {
   constructor() {
     this.repository = AppDataSource.getRepository(Parameter);
   }
-
   async create(parameter: Partial<Parameter>): Promise<Parameter> {
     const newParameter = this.repository.create(parameter);
     return await this.repository.save(newParameter);

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { errorMiddleware } from './web/middlewares/errorMiddleware';
 import { alertRoutes } from './web/routes/Alert.routes';
 import { measureRoutes } from './web/routes/Measure.routes';
 import { receiverJsonRoutes } from './web/routes/receiverJson.routes';
+import { dashboardRoutes } from './web/routes/dashboard.routes';
 import { swaggerOptions } from './swaggetOptions';
 
 const swaggerSpec = swaggerJsdoc(swaggerOptions);
@@ -42,6 +43,7 @@ app.use('/measure', measureRoutes);
 app.use('/alert', alertRoutes);
 app.use('/parameter', parameterRoutes);
 app.use('/receiverJson', receiverJsonRoutes);
+app.use('/dashboard', dashboardRoutes);
 
 // Middleware de erro (deve ser o último)
 app.use(errorMiddleware);

--- a/src/web/controllers/Dashboard/ListDashboard.ts
+++ b/src/web/controllers/Dashboard/ListDashboard.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from 'express';
+import { ListDashboardUseCase } from '../../../application/use-cases/dashboard/ListDashboardUseCase';
+
+export class ListDashboardController {
+  constructor(private listDashboardUseCase: ListDashboardUseCase) {}
+
+  async handle(request: Request, response: Response): Promise<Response> {
+    try {
+      const { 
+        startDate, 
+        endDate, 
+        stationId, 
+        parameterId 
+      } = request.query;
+
+      // Convert query string parameters to appropriate types
+      const filters = {
+        startDate: startDate ? new Date(startDate as string) : undefined,
+        endDate: endDate ? new Date(endDate as string) : undefined,
+        stationId: stationId ? String(stationId) : undefined,
+        parameterId: parameterId ? String(parameterId) : undefined
+      };
+
+      const dashboardData = await this.listDashboardUseCase.execute(filters);
+
+      return response.status(200).json({
+        success: true,
+        data: dashboardData
+      });
+    } catch (error) {
+      return response.status(400).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Erro inesperado'
+      });
+    }
+  }
+}

--- a/src/web/controllers/Dashboard/ListDashboard.ts
+++ b/src/web/controllers/Dashboard/ListDashboard.ts
@@ -1,17 +1,17 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import { ListDashboardUseCase } from '../../../application/use-cases/dashboard/ListDashboardUseCase';
 
 export class ListDashboardController {
   constructor(private listDashboardUseCase: ListDashboardUseCase) {}
 
-  async handle(request: Request, response: Response): Promise<Response> {
+  async getAll(req: Request, res, next: NextFunction): Promise<Response> {
     try {
       const { 
         startDate, 
         endDate, 
         stationId, 
         parameterId 
-      } = request.query;
+      } = req.query;
 
       // Convert query string parameters to appropriate types
       const filters = {
@@ -23,15 +23,10 @@ export class ListDashboardController {
 
       const dashboardData = await this.listDashboardUseCase.execute(filters);
 
-      return response.status(200).json({
-        success: true,
-        data: dashboardData
-      });
+      return res.sendSuccess(dashboardData, 200);
+      
     } catch (error) {
-      return response.status(400).json({
-        success: false,
-        error: error instanceof Error ? error.message : 'Erro inesperado'
-      });
+      next(error);
     }
   }
 }

--- a/src/web/routes/dashboard.routes.ts
+++ b/src/web/routes/dashboard.routes.ts
@@ -4,6 +4,8 @@ import { ListDashboardUseCase } from '../../application/use-cases/dashboard/List
 import { MeasureRepository } from '../../infrastructure/repositories/MeasureRepository';
 import StationRepository from '../../infrastructure/repositories/StationRepository';
 import { ParameterRepository } from '../../infrastructure/repositories/ParameterRepository';
+import { asyncHandler } from '../middlewares/asyncHandler';
+import { limiter } from "../../infrastructure/middlewares/limiter";
 
 const dashboardRoutes = Router();
 
@@ -18,9 +20,7 @@ const listDashboardUseCase = new ListDashboardUseCase(
 const listDashboardController = new ListDashboardController(listDashboardUseCase);
 
 // Define routes
-dashboardRoutes.get('/', (req, res) => {
-    return listDashboardController.handle(req, res);
-});
+dashboardRoutes.get('/list', limiter, asyncHandler((req, res, next) => listDashboardController.getAll(req, res, next)));
 
 // Additional dashboard routes can be added here
 

--- a/src/web/routes/dashboard.routes.ts
+++ b/src/web/routes/dashboard.routes.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import { ListDashboardController } from '../controllers/Dashboard/ListDashboard';
+import { ListDashboardUseCase } from '../../application/use-cases/dashboard/ListDashboardUseCase';
+import { MeasureRepository } from '../../infrastructure/repositories/MeasureRepository';
+import StationRepository from '../../infrastructure/repositories/StationRepository';
+import { ParameterRepository } from '../../infrastructure/repositories/ParameterRepository';
+
+const dashboardRoutes = Router();
+
+// Initialize use case
+const listDashboardUseCase = new ListDashboardUseCase(
+    new MeasureRepository(),
+    new StationRepository(),
+    new ParameterRepository()
+);
+
+// Initialize controller
+const listDashboardController = new ListDashboardController(listDashboardUseCase);
+
+// Define routes
+dashboardRoutes.get('/', (req, res) => {
+    return listDashboardController.handle(req, res);
+});
+
+// Additional dashboard routes can be added here
+
+export { dashboardRoutes };

--- a/tests/unit/useCases/dashboard/ListDashboard.test.ts
+++ b/tests/unit/useCases/dashboard/ListDashboard.test.ts
@@ -1,0 +1,90 @@
+import { ListDashboardUseCase } from "../../../../src/application/use-cases/dashboard/ListDashboardUseCase";
+import { IMeasureRepository } from "../../../../src/domain/interfaces/repositories/IMeasureRepository";
+import { IStationRepository } from "../../../../src/domain/interfaces/repositories/IStationRepository";
+import { IParameterRepository } from "../../../../src/domain/interfaces/repositories/IParameterRepository";
+import { timeStamp } from "console";
+
+const mockMeasureRepository = {
+    listWithFilters: jest.fn()
+};
+
+const mockParameterRepository = {
+    list: jest.fn(),
+    getWithParameterThenInclude: jest.fn()
+};
+
+const mockStationRepository = {
+    findById: jest.fn(),
+    list: jest.fn()
+};
+
+const makeUseCase = () => new ListDashboardUseCase(
+    mockMeasureRepository as unknown as IMeasureRepository,
+    mockStationRepository as unknown as IStationRepository,
+    mockParameterRepository as unknown as IParameterRepository
+);
+
+describe("ListDashboardUseCase", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("Should return structured dashboard data", async () => {
+        const filters = {
+            startDate: new Date("2023-01-01"),
+            endDate: new Date("2023-12-12")
+        };
+
+        const station = { id: 1, name: "Station 1", latitude: 10, longitude: 20 };
+        const typeParameter = { id: 1, name: "Temperature", unit: "°C", factor: 1, offset: 0, numberOfDecimalsCases: 2 };
+        const parameter = { id: 1, idStation: station, idTypeParameter: typeParameter };
+        const measurement = { id: 1, value: 25, unixTime: 1700000000, parameter: { id: 1 } };
+
+        mockMeasureRepository.listWithFilters.mockResolvedValue([measurement]);
+        mockStationRepository.list.mockResolvedValue([station]);
+        mockParameterRepository.list.mockResolvedValue([parameter]);
+        mockParameterRepository.getWithParameterThenInclude.mockResolvedValue(parameter);
+        
+        const useCase = makeUseCase();
+
+        const result = await useCase.execute(filters);
+
+        expect(result).toEqual({
+            stations: [
+                {
+                    id: 1,
+                    name: "Station 1",
+                    location: {
+                        latitude: 10,
+                        longitude: 20
+                    },
+                    parameters: [
+                    {
+                        id: 1,
+                        name: "Temperature",
+                        type: {
+                            id: 1,
+                            name: "Temperature",
+                            unit: "°C",
+                            factor: 1,
+                            offset: 0,
+                            decimalCases: 2
+                        },
+                        measurements: [
+                        {
+                            id: 1,
+                            value: 25,
+                            timestamp: new Date(1700000000 * 1000).toISOString()
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ],
+                timeRange: {
+                    start: new Date(1700000000 * 1000),
+                    end: new Date(1700000000 * 1000)
+            }
+        });
+    });
+});


### PR DESCRIPTION
# Criar endpoint para retornar os dados dos gráficos da dashboard

## Branch
- feat/A20-125/Criar-endpoint-para-retornar-os-dados

## Changelog:
- Adicionado o endpoint de listar as informações que seram usadas no dashboard

## Como Testar:
- Basta abrir o postman e colocar a seguinte rota: http://localhost:5000/dashboard/list
![image](https://github.com/user-attachments/assets/7ccdba90-4f38-4b32-ba43-282e7a062aa1)
- Teste vendo se esta printando as medições com os dias e horarios 
- Teste vendo se no final esta o horario e o dia certo de quando foi a primeira criação e a ultima