### PR TITLE
feat/A20-121/implementar-lógica-de-consulta-otimizada

### DIFF
--- a/src/application/use-cases/dashboard/ListDashboardUseCase.ts
+++ b/src/application/use-cases/dashboard/ListDashboardUseCase.ts
@@ -27,7 +27,6 @@ export class ListDashboardUseCase {
         parameterId: filters.parameterId
       });
       
-      // If no measurements found, return empty dashboard
       if (measurements.length === 0) {
         return {
           stations: [],
@@ -38,7 +37,6 @@ export class ListDashboardUseCase {
         };
       }
 
-      // Pega as estações com base no filtro
       const stations = filters.stationId 
         ? [await this.stationRepository.findById(filters.stationId)]
         : await this.stationRepository.list();
@@ -114,7 +112,6 @@ export class ListDashboardUseCase {
         ? stationsWithData 
         : stationsWithData.filter(s => s.hasData);
         
-      // Remove temporariamente a data do hash
       filteredStations.forEach(s => delete s.hasData);
       
       return {

--- a/src/infrastructure/repositories/MeasureRepository.ts
+++ b/src/infrastructure/repositories/MeasureRepository.ts
@@ -17,13 +17,11 @@ export class MeasureRepository implements IMeasureRepository {
       .leftJoinAndSelect('parameter.idTypeParameter', 'typeParameter');
     
     if (filters.startDate) {
-      // Converter data para timestamp unix (segundos)
       const startUnixTime = Math.floor(filters.startDate.getTime() / 1000);
       queryBuilder.andWhere('measure.unixTime >= :startUnixTime', { startUnixTime });
     }
     
     if (filters.endDate) {
-      // Converter data para timestamp unix (segundos)
       const endUnixTime = Math.floor(filters.endDate.getTime() / 1000);
       queryBuilder.andWhere('measure.unixTime <= :endUnixTime', { endUnixTime });
     }
@@ -36,24 +34,20 @@ export class MeasureRepository implements IMeasureRepository {
       queryBuilder.andWhere('station.id = :stationId', { stationId: filters.stationId });
     }
     
-    // Ordenar por timestamp para facilitar a visualização
     queryBuilder.orderBy('measure.unixTime', 'ASC');
     
     return await queryBuilder.getMany();
   }
 
-  // Método para criar um Measure
   async createMeasure(measure: Partial<Measure>): Promise<Measure> {
     return await this.measures.save(measure);
   }
 
-  // Método para buscar um Measure por ID
   async getById(id: string): Promise<Measure | null> {
     const measure = await this.measures.findOne({ where: { id } });
     return measure || null;
   }
 
-  // Método para listar todos os Measures
   async listMeasures(
     stationId: string | null
   ): Promise<ListMeasureResponseDTO[]> {
@@ -87,13 +81,11 @@ export class MeasureRepository implements IMeasureRepository {
     );
   }
 
-  // Método para excluir um Measure
   async deleteMeasure(id: string): Promise<boolean> {
     const result = await this.measures.delete(id);
     return result.affected !== 0;
   }
 
-  // Método para atualizar um Measure
   async updateMeasure(measure: Measure): Promise<Measure> {
     return await this.measures.save(measure);
   }

--- a/src/web/controllers/Dashboard/ListDashboard.ts
+++ b/src/web/controllers/Dashboard/ListDashboard.ts
@@ -9,14 +9,45 @@ export class ListDashboardController {
       const { 
         startDate, 
         endDate, 
+        date,
         stationId, 
-        parameterId 
+        parameterId,
+        lastDays
       } = req.query;
 
-      // Convert query string parameters to appropriate types
+      let startDateObj: Date | undefined = undefined;
+      let endDateObj: Date | undefined = undefined;
+      
+      // Se foi solicitado os últimos N dias
+      if (lastDays) {
+        const days = parseInt(lastDays as string, 10);
+        endDateObj = new Date(); // Hora atual
+        startDateObj = new Date();
+        startDateObj.setDate(startDateObj.getDate() - days);
+      }
+      // Se um único dia for especificado
+      else if (date) {
+        const dateStr = date as string;
+        
+        // Cria data no fuso UTC
+        startDateObj = new Date(`${dateStr}T00:00:00-03:00`); // Considerando fuso -03:00 do Brasil
+        endDateObj = new Date(`${dateStr}T23:59:59.999-03:00`);
+      } 
+      // Se um intervalo for especificado
+      else {
+        if (startDate) {
+          startDateObj = new Date(startDate as string);
+        }
+        
+        if (endDate) {
+          endDateObj = new Date(endDate as string);
+        }
+      }
+
+      // Converte os parâmetros de query string para os tipos apropriados
       const filters = {
-        startDate: startDate ? new Date(startDate as string) : undefined,
-        endDate: endDate ? new Date(endDate as string) : undefined,
+        startDate: startDateObj,
+        endDate: endDateObj,
         stationId: stationId ? String(stationId) : undefined,
         parameterId: parameterId ? String(parameterId) : undefined
       };

--- a/src/web/controllers/Dashboard/ListDashboard.ts
+++ b/src/web/controllers/Dashboard/ListDashboard.ts
@@ -18,22 +18,18 @@ export class ListDashboardController {
       let startDateObj: Date | undefined = undefined;
       let endDateObj: Date | undefined = undefined;
       
-      // Se foi solicitado os últimos N dias
       if (lastDays) {
         const days = parseInt(lastDays as string, 10);
-        endDateObj = new Date(); // Hora atual
+        endDateObj = new Date();
         startDateObj = new Date();
         startDateObj.setDate(startDateObj.getDate() - days);
       }
-      // Se um único dia for especificado
       else if (date) {
         const dateStr = date as string;
         
-        // Cria data no fuso UTC
-        startDateObj = new Date(`${dateStr}T00:00:00-03:00`); // Considerando fuso -03:00 do Brasil
+        startDateObj = new Date(`${dateStr}T00:00:00-03:00`);
         endDateObj = new Date(`${dateStr}T23:59:59.999-03:00`);
       } 
-      // Se um intervalo for especificado
       else {
         if (startDate) {
           startDateObj = new Date(startDate as string);
@@ -44,7 +40,6 @@ export class ListDashboardController {
         }
       }
 
-      // Converte os parâmetros de query string para os tipos apropriados
       const filters = {
         startDate: startDateObj,
         endDate: endDateObj,

--- a/src/web/routes/dashboard.routes.ts
+++ b/src/web/routes/dashboard.routes.ts
@@ -6,6 +6,7 @@ import StationRepository from '../../infrastructure/repositories/StationReposito
 import { ParameterRepository } from '../../infrastructure/repositories/ParameterRepository';
 import { asyncHandler } from '../middlewares/asyncHandler';
 import { limiter } from "../../infrastructure/middlewares/limiter";
+import { ensureAuthenticated } from "../../infrastructure/middlewares/ensureAuthenticated";
 
 const dashboardRoutes = Router();
 
@@ -19,9 +20,16 @@ const listDashboardUseCase = new ListDashboardUseCase(
 // Initialize controller
 const listDashboardController = new ListDashboardController(listDashboardUseCase);
 
-// Define routes
-dashboardRoutes.get('/list', limiter, asyncHandler((req, res, next) => listDashboardController.getAll(req, res, next)));
+// Rota pública - limitada aos últimos 7 dias para usuários não autenticados
+dashboardRoutes.get('/public', limiter, asyncHandler((req, res, next) => {
+    // Força a configuração para os últimos 7 dias
+    req.query.lastDays = '7';
+    return listDashboardController.getAll(req, res, next);
+}));
 
-// Additional dashboard routes can be added here
+// Rota protegida - permite todos os filtros para usuários autenticados
+dashboardRoutes.get('/list', limiter, ensureAuthenticated, asyncHandler((req, res, next) => 
+    listDashboardController.getAll(req, res, next)
+));
 
 export { dashboardRoutes };

--- a/src/web/routes/dashboard.routes.ts
+++ b/src/web/routes/dashboard.routes.ts
@@ -10,24 +10,19 @@ import { ensureAuthenticated } from "../../infrastructure/middlewares/ensureAuth
 
 const dashboardRoutes = Router();
 
-// Initialize use case
 const listDashboardUseCase = new ListDashboardUseCase(
     new MeasureRepository(),
     new StationRepository(),
     new ParameterRepository()
 );
 
-// Initialize controller
 const listDashboardController = new ListDashboardController(listDashboardUseCase);
 
-// Rota pública - limitada aos últimos 7 dias para usuários não autenticados
 dashboardRoutes.get('/public', limiter, asyncHandler((req, res, next) => {
-    // Força a configuração para os últimos 7 dias
     req.query.lastDays = '7';
     return listDashboardController.getAll(req, res, next);
 }));
 
-// Rota protegida - permite todos os filtros para usuários autenticados
 dashboardRoutes.get('/list', limiter, ensureAuthenticated, asyncHandler((req, res, next) => 
     listDashboardController.getAll(req, res, next)
 ));

--- a/tests/unit/useCases/dashboard/ListDashboard.test.ts
+++ b/tests/unit/useCases/dashboard/ListDashboard.test.ts
@@ -90,7 +90,6 @@ describe("ListDashboardUseCase", () => {
                 }
         });
         
-        // Verifica se o repository foi chamado com os filtros corretos
         expect(mockMeasureRepository.listWithFilters).toHaveBeenCalledWith({
             startDate: new Date("2023-01-01"),
             endDate: new Date("2023-12-12"),
@@ -117,11 +116,9 @@ describe("ListDashboardUseCase", () => {
         const useCase = makeUseCase();
         const result = await useCase.execute(filters);
         
-        // Verifica se o repository de estação foi chamado com o ID correto
         expect(mockStationRepository.findById).toHaveBeenCalledWith("station-123");
         expect(mockStationRepository.list).not.toHaveBeenCalled();
         
-        // Verifica se os filtros foram passados corretamente para o repository
         expect(mockMeasureRepository.listWithFilters).toHaveBeenCalledWith({
             stationId: "station-123",
             startDate: undefined,
@@ -144,7 +141,6 @@ describe("ListDashboardUseCase", () => {
             }
         });
         
-        // Não deve chamar os outros repositories se não há medições
         expect(mockStationRepository.list).not.toHaveBeenCalled();
         expect(mockParameterRepository.list).not.toHaveBeenCalled();
     });
@@ -167,7 +163,6 @@ describe("ListDashboardUseCase", () => {
         const useCase = makeUseCase();
         const result = await useCase.execute(filters);
         
-        // Verifica se os filtros foram passados corretamente para o repository
         expect(mockMeasureRepository.listWithFilters).toHaveBeenCalledWith({
             parameterId: "param-123",
             startDate: undefined,

--- a/tests/unit/useCases/dashboard/ListDashboard.test.ts
+++ b/tests/unit/useCases/dashboard/ListDashboard.test.ts
@@ -2,7 +2,6 @@ import { ListDashboardUseCase } from "../../../../src/application/use-cases/dash
 import { IMeasureRepository } from "../../../../src/domain/interfaces/repositories/IMeasureRepository";
 import { IStationRepository } from "../../../../src/domain/interfaces/repositories/IStationRepository";
 import { IParameterRepository } from "../../../../src/domain/interfaces/repositories/IParameterRepository";
-import { timeStamp } from "console";
 
 const mockMeasureRepository = {
     listWithFilters: jest.fn()
@@ -84,7 +83,96 @@ describe("ListDashboardUseCase", () => {
                 timeRange: {
                     start: new Date(1700000000 * 1000),
                     end: new Date(1700000000 * 1000)
+                },
+                filters: {
+                    startDate: new Date("2023-01-01"),
+                    endDate: new Date("2023-12-12")
+                }
+        });
+        
+        // Verifica se o repository foi chamado com os filtros corretos
+        expect(mockMeasureRepository.listWithFilters).toHaveBeenCalledWith({
+            startDate: new Date("2023-01-01"),
+            endDate: new Date("2023-12-12"),
+            stationId: undefined,
+            parameterId: undefined
+        });
+    });
+    
+    it("Should filter by specific station ID", async () => {
+        const filters = {
+            stationId: "station-123"
+        };
+        
+        const station = { id: "station-123", name: "Specific Station", latitude: 10, longitude: 20 };
+        const typeParameter = { id: 1, name: "Temperature", unit: "°C", factor: 1, offset: 0, numberOfDecimalsCases: 2 };
+        const parameter = { id: 1, idStation: station, idTypeParameter: typeParameter };
+        const measurement = { id: 1, value: 25, unixTime: 1700000000, parameter: { id: 1 } };
+
+        mockMeasureRepository.listWithFilters.mockResolvedValue([measurement]);
+        mockStationRepository.findById.mockResolvedValue(station);
+        mockParameterRepository.list.mockResolvedValue([parameter]);
+        mockParameterRepository.getWithParameterThenInclude.mockResolvedValue(parameter);
+        
+        const useCase = makeUseCase();
+        const result = await useCase.execute(filters);
+        
+        // Verifica se o repository de estação foi chamado com o ID correto
+        expect(mockStationRepository.findById).toHaveBeenCalledWith("station-123");
+        expect(mockStationRepository.list).not.toHaveBeenCalled();
+        
+        // Verifica se os filtros foram passados corretamente para o repository
+        expect(mockMeasureRepository.listWithFilters).toHaveBeenCalledWith({
+            stationId: "station-123",
+            startDate: undefined,
+            endDate: undefined,
+            parameterId: undefined
+        });
+    });
+    
+    it("Should handle empty measurements", async () => {
+        mockMeasureRepository.listWithFilters.mockResolvedValue([]);
+        
+        const useCase = makeUseCase();
+        const result = await useCase.execute();
+        
+        expect(result).toEqual({
+            stations: [],
+            timeRange: {
+                start: null,
+                end: null
             }
+        });
+        
+        // Não deve chamar os outros repositories se não há medições
+        expect(mockStationRepository.list).not.toHaveBeenCalled();
+        expect(mockParameterRepository.list).not.toHaveBeenCalled();
+    });
+    
+    it("Should filter by specific parameter ID", async () => {
+        const filters = {
+            parameterId: "param-123"
+        };
+        
+        const station = { id: 1, name: "Station 1", latitude: 10, longitude: 20 };
+        const typeParameter = { id: 1, name: "Specific Parameter", unit: "°C", factor: 1, offset: 0, numberOfDecimalsCases: 2 };
+        const parameter = { id: "param-123", idStation: station, idTypeParameter: typeParameter };
+        const measurement = { id: 1, value: 25, unixTime: 1700000000, parameter: { id: "param-123" } };
+
+        mockMeasureRepository.listWithFilters.mockResolvedValue([measurement]);
+        mockStationRepository.list.mockResolvedValue([station]);
+        mockParameterRepository.list.mockResolvedValue([parameter]);
+        mockParameterRepository.getWithParameterThenInclude.mockResolvedValue(parameter);
+        
+        const useCase = makeUseCase();
+        const result = await useCase.execute(filters);
+        
+        // Verifica se os filtros foram passados corretamente para o repository
+        expect(mockMeasureRepository.listWithFilters).toHaveBeenCalledWith({
+            parameterId: "param-123",
+            startDate: undefined,
+            endDate: undefined,
+            stationId: undefined
         });
     });
 });


### PR DESCRIPTION
# Implementar lógica de consulta otimizada por intervalo de datas.

## Branch
- feat/A20-121/implementar-lógica-de-consulta-otimizada

## Changelog:
- Adicionada a rota privada onde vai listar todos os dados para o dashboard
- Na rota privada pode ser filtrada por intervalo de data e uma data especifica
- Adicionada a rota publica onde vai listar os dados dos ultimos 7 dias para o dashboard

## Como Testar:
- Abra o postman e primeiro teste a rota publica: http://localhost:5000/dashboard/public/
![image](https://github.com/user-attachments/assets/16ab45bb-b257-4f3b-9f5c-91f83b8180a4)
- Agora teste a rota publica pegando o token do usuario e passando ele junto da rota: http://localhost:5000/dashboard/list
- Teste também os de intervalo de tempo: http://localhost:5000/dashboard/list?startDate=2025-04-08&endDate=2025-04-09
- Teste o de uma data especifica: http://localhost:5000/dashboard/list?date=2025-04-08