### PR TITLE
feat/a20-133/criar-filtro-por-data-para-medias

### DIFF
--- a/src/application/use-cases/measureAverage/CreateMeasureAverageUseCase.ts
+++ b/src/application/use-cases/measureAverage/CreateMeasureAverageUseCase.ts
@@ -96,7 +96,7 @@ export class CreateMeasureAverageUseCase {
                 const measureAverage = new MeasureAverage();
                 measureAverage.CreateMeasureAverage(
                     enumTypeAverage,
-                    `${group.stationName} - ${group.parameterName}`,
+                    `${group.parameterName}`,
                     average.toFixed(2)
                 );
 

--- a/src/application/use-cases/measureAverage/ListMeasureAverageUseCase.ts
+++ b/src/application/use-cases/measureAverage/ListMeasureAverageUseCase.ts
@@ -14,9 +14,38 @@ export default class ListMeasureAverageUseCase {
 
         if (!station) throw new SystemContextException("Estação não encontrada")
 
-        const response = await this.measureAverageRepository.listMeasuresAverages(stationId); 
+        const response = await this.measureAverageRepository.listMeasuresAveragesLast7Days(stationId);
 
         if (response.length == 0) throw new SystemContextException("Nenhuma media de medida para listar") 
+
+        return response;
+    }
+
+    async executeWithStartAndEnd(stationId: string, start: string, end: string): Promise<MeasureAverage[]> {
+        const station = await this.stationRepository.findById(stationId);
+
+        if (!station) throw new SystemContextException("Estação não encontrada")
+
+        const startDate = new Date(start);
+        const endDate = new Date(end);
+
+        const response = await this.measureAverageRepository.listMeasuresAveragesWithStartAndEnd(stationId, startDate, endDate);
+
+        if (response.length == 0) throw new SystemContextException("Nenhuma media de medida para listar") 
+
+        return response;
+    }
+
+    async executeWithDate(stationId: string, date: string): Promise<MeasureAverage[]> {
+        const station = await this.stationRepository.findById(stationId);
+
+        if (!station) throw new SystemContextException("Estação não encontrada")
+
+        const dateObj = new Date(date);
+        
+        const response = await this.measureAverageRepository.listMeasuresAveragesWithDate(stationId, dateObj);
+
+        if (response.length == 0) throw new SystemContextException("Nenhuma media de medida para esta data")
 
         return response;
     }

--- a/src/application/use-cases/receiverJson/receiverJsonUseCase.ts
+++ b/src/application/use-cases/receiverJson/receiverJsonUseCase.ts
@@ -37,7 +37,7 @@ export default class ReceiverJsonUseCase {
         for (const [key, value] of Object.entries(measurements)) {
             const parameter = station.parameters.find(p => p.idTypeParameter.typeJson === key);
             if (!parameter) {
-                throw new SystemContextException(`Tipo de dado não encontrado: ${key}`);
+                continue;
             }
 
             const measureData: RegisterMeasureDTO = {

--- a/src/domain/interfaces/repositories/IMeasureAverageRepository.ts
+++ b/src/domain/interfaces/repositories/IMeasureAverageRepository.ts
@@ -4,5 +4,8 @@ export interface IMeasureAverageRepository {
     createMeasureAverage(measureAverage: Partial<MeasureAverage>): Promise<MeasureAverage>;
     getById(id: string): Promise<MeasureAverage | null>;
     listMeasuresAverages(stationId: string): Promise<MeasureAverage[]>;
+    listMeasuresAveragesWithStartAndEnd(stationId: string, start: Date, end: Date): Promise<MeasureAverage[]>;
+    listMeasuresAveragesLast7Days(stationId: string): Promise<MeasureAverage[]>;
+    listMeasuresAveragesWithDate(stationId: string, date: Date): Promise<MeasureAverage[]>;
     deleteMeasureAverage(id: string): Promise<boolean>;
 }

--- a/src/domain/models/agregates/Parameter/Parameter.ts
+++ b/src/domain/models/agregates/Parameter/Parameter.ts
@@ -22,6 +22,6 @@ export default class Parameter {
     measures: Measure[];
 
     public getParameterName(): string {
-        return this.idStation.name + " - " + this.idTypeParameter.name;
+        return this.idTypeParameter.name;
     }
 }

--- a/src/infrastructure/repositories/MeasureAverageRepository.ts
+++ b/src/infrastructure/repositories/MeasureAverageRepository.ts
@@ -1,7 +1,9 @@
-import { Between, Repository } from "typeorm";
+import { Between, MoreThan, Repository } from "typeorm";
 import { MeasureAverage } from "../../domain/models/entities/MeasureAverage";
 import { AppDataSource } from "../database/data-source";
 import { IMeasureAverageRepository } from "../../domain/interfaces/repositories/IMeasureAverageRepository";
+import { startOfDay } from "date-fns";
+import { endOfDay } from "date-fns";
 
 export class MeasureAverageRepository implements IMeasureAverageRepository {
     private measuresAverage: Repository<MeasureAverage> = AppDataSource.getRepository(MeasureAverage);
@@ -22,7 +24,44 @@ export class MeasureAverageRepository implements IMeasureAverageRepository {
             where: { station: { id: stationId } }
         });
     }
+    
 
+    async listMeasuresAveragesWithStartAndEnd(stationId: string, start: Date, end: Date): Promise<MeasureAverage[]> {
+        const startDate = new Date(start);
+        startDate.setUTCHours(0, 0, 0, 0);
+        
+        const endDate = new Date(end);
+        endDate.setUTCHours(23, 59, 59, 999);
+
+        return await this.measuresAverage.find({
+            where: {
+                station: { id: stationId },
+                createdAt: Between(startDate, endDate)
+            }
+        });
+    }
+    
+    async listMeasuresAveragesLast7Days(stationId: string): Promise<MeasureAverage[]> {
+        return await this.measuresAverage.find({
+            where: { station: { id: stationId }, createdAt: MoreThan(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)) }
+        });
+    }
+
+    async listMeasuresAveragesWithDate(stationId: string, date: Date): Promise<MeasureAverage[]> {
+        const start = new Date(date);
+        start.setUTCHours(0, 0, 0, 0);
+        
+        const end = new Date(date);
+        end.setUTCHours(23, 59, 59, 999);        
+    
+        return await this.measuresAverage.find({
+            where: {
+                station: { id: stationId },
+                createdAt: Between(start, end)
+            }
+        });
+    }
+    
     async deleteMeasureAverage(id: string): Promise<boolean> {
         const result = await this.measuresAverage.delete(id);
         return result.affected ? result.affected > 0 : false;

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import { emailStationRoutes } from './web/routes/emailStation.router';
 import { CronManager } from './infrastructure/nodeCron/CronManager';
 import { createSocketServer } from './infrastructure/websocket/socket';
 import measureAverageRoutes from './web/routes/MeasureAverage.routes';
-
+import { dashboardRoutes } from './web/routes/dashboard.routes';
 const swaggerSpec = swaggerJsdoc(swaggerOptions);
 export const app = express();
 app.use(cors());
@@ -42,6 +42,7 @@ app.use("/parameter", parameterRoutes);
 app.use("/receiverJson", receiverJsonRoutes);
 app.use("/emailStation", emailStationRoutes);
 app.use("/measureAverage", measureAverageRoutes);
+app.use("/dashboard", dashboardRoutes);
 app.use(errorMiddleware);
 
 // --- Controle de recursos ---

--- a/src/web/controllers/MeasureAverage/ListMeasureAverageController.ts
+++ b/src/web/controllers/MeasureAverage/ListMeasureAverageController.ts
@@ -15,4 +15,30 @@ export class ListMeasureAverageController {
             next(error);
         }
     }
+
+    async handleWithStartAndEnd(request: Request, response: Response, next: NextFunction) {
+        try {
+            const stationId = request.params.stationId;
+            const start = request.params.start;
+            const end = request.params.end;
+
+            const measures = await this.listMeasureAverageUseCase.executeWithStartAndEnd(stationId, start, end);
+
+            return response.sendSuccess(measures, 200);
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async handleWithDate(request: Request, response: Response, next: NextFunction) {
+        try {
+            const stationId = request.params.stationId;
+            const date = request.params.date;
+            const measures = await this.listMeasureAverageUseCase.executeWithDate(stationId, date);
+
+            return response.sendSuccess(measures, 200);
+        } catch (error) {
+            next(error);
+        }
+    }
 }

--- a/src/web/routes/MeasureAverage.routes.ts
+++ b/src/web/routes/MeasureAverage.routes.ts
@@ -5,6 +5,7 @@ import { ListMeasureAverageController } from "../controllers/MeasureAverage/List
 import { limiter } from "../../infrastructure/middlewares/limiter";
 import { asyncHandler } from "../middlewares/asyncHandler";
 import StationRepository from "../../infrastructure/repositories/StationRepository";
+import { ensureAuthenticated } from "../../infrastructure/middlewares/ensureAuthenticated";
 
 // Repositories
 const measureAverageRepository = new MeasureAverageRepository();
@@ -18,6 +19,8 @@ const listMeasureAverageController = new ListMeasureAverageController(listMeasur
 
 const measureAverageRoutes = Router();
 
-measureAverageRoutes.get("/:stationId", limiter, asyncHandler((req, res, next) => listMeasureAverageController.handle(req, res, next)));
+measureAverageRoutes.get("/public/:stationId", limiter, asyncHandler((req, res, next) => listMeasureAverageController.handle(req, res, next)));
+measureAverageRoutes.get("/:stationId/:start/:end", limiter, ensureAuthenticated, asyncHandler((req, res, next) => listMeasureAverageController.handleWithStartAndEnd(req, res, next)));
+measureAverageRoutes.get("/:stationId/:date", limiter, ensureAuthenticated, asyncHandler((req, res, next) => listMeasureAverageController.handleWithDate(req, res, next)));
 
 export default measureAverageRoutes;

--- a/tests/integration/measureAverage/ListMeasureAverage.test.ts
+++ b/tests/integration/measureAverage/ListMeasureAverage.test.ts
@@ -10,55 +10,59 @@ import SetupIntegration, { getDataSource } from '../setup/SetupIntegration';
 import { clearDatabase } from '../setup/DatabaseCleaner';
 import request from 'supertest';
 import { app } from '../../../src/server';
+
 let dataSource: DataSource;
 let useCase: CreateMeasureAverageUseCase;
+let measureAverageRepo: MeasureAverageRepository;
+let measureRepo: MeasureRepository;
 
 beforeAll(async () => {
   await SetupIntegration();
+  dataSource = getDataSource();
 });
 
 beforeEach(async () => {
-  dataSource = getDataSource();
   await clearDatabase(dataSource);
+  measureAverageRepo = new MeasureAverageRepository();
+  measureRepo = new MeasureRepository();
+  useCase = new CreateMeasureAverageUseCase(measureAverageRepo, measureRepo);
 });
 
-describe('Testes de Integração para ler média de medidas - /measure/average', () => {
+afterAll(async () => {
+  await dataSource.destroy();
+});
+
+describe('Testes de Integração para ler média de medidas - /measureAverage', () => {
   test('✅ Deve retornar status 200 e a lista de media de medidas', async () => {
     const stations = await runStationSeeds(dataSource);
     const typeParameters = await runTypeParameterSeeds(dataSource);
     const parameters = await runParameterSeeds(dataSource, stations, typeParameters);
     await runMeasureSeeds(dataSource, parameters);
 
-    const measureAverageRepo = new MeasureAverageRepository();
-
-    useCase = new CreateMeasureAverageUseCase(
-      measureAverageRepo,
-      new MeasureRepository()
-    );
-
+    // Gera médias para os testes
     await useCase.executeLastHour();
 
-    const response = await request(app).get('/measureAverage/' + stations[1].id);
+    const response = await request(app).get('/measureAverage/public/' + stations[1].id);
 
     expect(response.status).toBe(200);
     expect(response.body.status).toBe(200);
     expect(Array.isArray(response.body.model)).toBe(true);
-
+    expect(response.body.model.length).toBeGreaterThan(0);
   });
 
   test('❌ Deve retornar status 400 caso a estação nao exista', async () => {
-    const response = await request(app).get('/measureAverage/' + '12345678-1234-1234-1234-123456789012');
+    const nonExistingStationId = '12345678-1234-1234-1234-123456789012';
+    const response = await request(app).get('/measureAverage/public/' + nonExistingStationId);
 
     expect(response.status).toBe(400);
     expect(response.body.status).toBe(400);
     expect(response.body.error).toBe("Estação não encontrada");
-  }
-  );
+  });
 
   test('❌ Deve retornar status 400 caso não haja media de medidas', async () => {
     const stations = await runStationSeeds(dataSource);
 
-    const response = await request(app).get('/measureAverage/' + stations[0].id);
+    const response = await request(app).get('/measureAverage/public/' + stations[0].id);
 
     expect(response.status).toBe(400);
     expect(response.body.status).toBe(400);

--- a/tests/unit/useCases/measureAverage/CreateMeasureAverageUseCase.test.ts
+++ b/tests/unit/useCases/measureAverage/CreateMeasureAverageUseCase.test.ts
@@ -16,7 +16,10 @@ describe('CreateMeasureAverageUseCase', () => {
             createMeasureAverage: jest.fn(),
             getById: jest.fn(),
             listMeasuresAverages: jest.fn(),
-            deleteMeasureAverage: jest.fn()
+            deleteMeasureAverage: jest.fn(),
+            listMeasuresAveragesWithStartAndEnd: jest.fn(),
+            listMeasuresAveragesLast7Days: jest.fn(),
+            listMeasuresAveragesWithDate: jest.fn(),
         } as jest.Mocked<IMeasureAverageRepository>;
 
         mockMeasureRepository = {

--- a/tests/unit/useCases/measureAverage/ListMeasureAverageUseCase.test.ts
+++ b/tests/unit/useCases/measureAverage/ListMeasureAverageUseCase.test.ts
@@ -15,7 +15,10 @@ describe('ListMeasureAverageUseCase', () => {
             createMeasureAverage: jest.fn(),
             getById: jest.fn(),
             listMeasuresAverages: jest.fn(),
-            deleteMeasureAverage: jest.fn()
+            deleteMeasureAverage: jest.fn(),
+            listMeasuresAveragesWithStartAndEnd: jest.fn(),
+            listMeasuresAveragesLast7Days: jest.fn(),
+            listMeasuresAveragesWithDate: jest.fn()
         } as jest.Mocked<IMeasureAverageRepository>;
 
         mockStationRepository = {
@@ -53,7 +56,7 @@ describe('ListMeasureAverageUseCase', () => {
             createMockMeasureAverage('2', enumAverage.HOUR, 'Estação teste - Umidade', '65.3')
         ];
 
-        mockMeasureAverageRepository.listMeasuresAverages.mockResolvedValue(mockMeasureAverages);
+        mockMeasureAverageRepository.listMeasuresAveragesLast7Days.mockResolvedValue(mockMeasureAverages);
 
         const result = await listMeasureAverageUseCase.execute(stationId);
 
@@ -64,8 +67,8 @@ describe('ListMeasureAverageUseCase', () => {
         expect(result[0].GetName()).toBe('Estação teste - Temperatura');
         expect(result[0].GetValue()).toBe('25.5');
         expect(mockStationRepository.findById).toHaveBeenCalledWith(stationId);
-        expect(mockMeasureAverageRepository.listMeasuresAverages).toHaveBeenCalledWith(stationId);
-        expect(mockMeasureAverageRepository.listMeasuresAverages).toHaveBeenCalledTimes(1);
+        expect(mockMeasureAverageRepository.listMeasuresAveragesLast7Days).toHaveBeenCalledWith(stationId);
+        expect(mockMeasureAverageRepository.listMeasuresAveragesLast7Days).toHaveBeenCalledTimes(1);
     });
 
     it('❌ Deve lançar exceção quando não houver dados para retornar', async () => {
@@ -79,15 +82,15 @@ describe('ListMeasureAverageUseCase', () => {
         } as any);
 
         // Simula retorno vazio de medidas
-        mockMeasureAverageRepository.listMeasuresAverages.mockResolvedValue([]);
+        mockMeasureAverageRepository.listMeasuresAveragesLast7Days.mockResolvedValue([]);
 
         await expect(listMeasureAverageUseCase.execute(stationId))
             .rejects
             .toThrow(new SystemContextException('Nenhuma media de medida para listar'));
 
         expect(mockStationRepository.findById).toHaveBeenCalledWith(stationId);
-        expect(mockMeasureAverageRepository.listMeasuresAverages).toHaveBeenCalledWith(stationId);
-        expect(mockMeasureAverageRepository.listMeasuresAverages).toHaveBeenCalledTimes(1);
+        expect(mockMeasureAverageRepository.listMeasuresAveragesLast7Days).toHaveBeenCalledWith(stationId);
+        expect(mockMeasureAverageRepository.listMeasuresAveragesLast7Days).toHaveBeenCalledTimes(1);
     });
 
     it('❌ Deve lançar exceção quando a estação não for encontrada', async () => {
@@ -103,7 +106,7 @@ describe('ListMeasureAverageUseCase', () => {
         expect(mockStationRepository.findById).toHaveBeenCalledWith(stationId);
         expect(mockStationRepository.findById).toHaveBeenCalledTimes(1);
         // Não deve chegar a chamar o repository de medidas se a estação não for encontrada
-        expect(mockMeasureAverageRepository.listMeasuresAverages).not.toHaveBeenCalled();
+        expect(mockMeasureAverageRepository.listMeasuresAveragesLast7Days).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
# Criar endpoints para retornar as médias horárias e diárias com filtros por data e estação.

## Branch
- feat/A20-133/criar-filtro-por-data-para-medias

## Changelog:
![image](https://github.com/user-attachments/assets/2586de5a-1e73-4e0b-96d4-be43fd95221e)
- Rota publica para listar os ultimos 7 dias
- Rota privada consegue utilizar o filtro

## Como Testar:
- http://localhost:5000/measureAverage/public/{stationID} lista os ultimos 7 dias
- http://localhost:5000/measureAverage/{stationId}/{date} lista uma data especifica
- http://localhost:5000/measureAverage/{stationId}/{startDate}/{endDate} filtra entre as datas

## Dependências:
- npm i