### PR TITLE
refactor/A20-154/arrumar-endpoint-do-dashboard

### DIFF
--- a/src/application/use-cases/dashboard/ListDashboardUseCase.ts
+++ b/src/application/use-cases/dashboard/ListDashboardUseCase.ts
@@ -1,15 +1,6 @@
 import { IMeasureRepository } from "../../../domain/interfaces/repositories/IMeasureRepository";
 import { IStationRepository } from "../../../domain/interfaces/repositories/IStationRepository";
 import { IParameterRepository } from "../../../domain/interfaces/repositories/IParameterRepository";
-import { Measure } from "../../../domain/models/entities/Measure";
-
-interface DashboardFilters {
-  startDate?: Date;
-  endDate?: Date;
-  stationId?: string;
-  parameterId?: string;
-}
-
 export class ListDashboardUseCase {
   constructor(
     private measurementRepository: IMeasureRepository,
@@ -17,140 +8,12 @@ export class ListDashboardUseCase {
     private parameterRepository: IParameterRepository
   ) {}
 
-  async execute(filters: DashboardFilters = {}) {
-    try {
-      // Get all measurements matching the filters
-      const measurements = await this.measurementRepository.listWithFilters({
-        startDate: filters.startDate,
-        endDate: filters.endDate,
-        stationId: filters.stationId,
-        parameterId: filters.parameterId
-      });
-      
-      if (measurements.length === 0) {
-        return {
-          stations: [],
-          timeRange: {
-            start: filters.startDate || null,
-            end: filters.endDate || null
-          }
-        };
-      }
-
-      const stations = filters.stationId 
-        ? [await this.stationRepository.findById(filters.stationId)]
-        : await this.stationRepository.list();
-      
-      // Pega os parametro com seus relacionados
-      const parameters = await Promise.all(
-        (await this.parameterRepository.list()).map(async p => {
-          return await this.parameterRepository.getWithParameterThenInclude(p.id);
-        })
-      ).then(params => params.filter(p => p !== null));
-      
-      // Agrupa as medições com o ID do parametro
-      const measurementsByParameter = new Map();
-      
-      for (const measurement of measurements) {
-        if (!measurement.parameter || !measurement.parameter.id) {
-          continue;
-        }
-        
-        const parameterId = measurement.parameter.id;
-        
-        if (!measurementsByParameter.has(parameterId)) {
-          measurementsByParameter.set(parameterId, []);
-        }
-        
-        measurementsByParameter.get(parameterId).push({
-          id: measurement.id,
-          value: measurement.value,
-          timestamp: new Date(measurement.unixTime * 1000).toISOString()
-        });
-      }
-      
-      const stationsWithData = stations.map(station => {
-        const stationParameters = parameters.filter(p => 
-          p.idStation && p.idStation.id === station.id
-        );
-        
-        const parametersWithDetails = stationParameters.map(param => {
-          const typeParam = param.idTypeParameter;
-          
-          const measurementsForParameter = measurementsByParameter.get(param.id) || [];
-          
-          return {
-            id: param.id,
-            name: typeParam ? typeParam.name : "Unknown Parameter",
-            type: typeParam ? {
-              id: typeParam.id,
-              name: typeParam.name,
-              unit: typeParam.unit,
-              factor: typeParam.factor,
-              offset: typeParam.offset,
-              decimalCases: typeParam.numberOfDecimalsCases
-            } : null,
-            measurements: measurementsForParameter
-          };
-        });
-        
-        const hasAnyMeasurements = parametersWithDetails.some(p => p.measurements.length > 0);
-        
-        return {
-          id: station.id,
-          name: station.name,
-          location: {
-            latitude: station.latitude,
-            longitude: station.longitude
-          },
-          parameters: parametersWithDetails,
-          hasData: hasAnyMeasurements
-        };
-      });
-      
-      const filteredStations = filters.stationId 
-        ? stationsWithData 
-        : stationsWithData.filter(s => s.hasData);
-        
-      filteredStations.forEach(s => delete s.hasData);
-      
-      return {
-        stations: filteredStations,
-        timeRange: {
-          start: this.getMinDate(measurements),
-          end: this.getMaxDate(measurements)
-        },
-        filters: {
-          startDate: filters.startDate,
-          endDate: filters.endDate,
-          stationId: filters.stationId,
-          parameterId: filters.parameterId
-        }
-      };
-    } catch (error) {
-      throw error;
+  async execute(stationId: string, startDate: Date, endDate: Date) {
+    if (startDate && endDate) {
+      const measures = await this.measurementRepository.listWithFilters(startDate, endDate, stationId);
+      return measures;
     }
-  }
-
-  private getMinDate(measurements: Measure[]): Date | null {
-    if (!measurements || measurements.length === 0) {
-      return null;
-    }
-    const timestamps = measurements
-      .map(m => m.unixTime)
-      .filter(t => t !== undefined && t !== null);
-    
-    return timestamps.length > 0 ? new Date(Math.min(...timestamps) * 1000) : null;
-  }
-
-  private getMaxDate(measurements: Measure[]): Date | null {
-    if (!measurements || measurements.length === 0) {
-      return null;
-    }
-    const timestamps = measurements
-      .map(m => m.unixTime)
-      .filter(t => t !== undefined && t !== null);
-    
-    return timestamps.length > 0 ? new Date(Math.max(...timestamps) * 1000) : null;
+    const measures = await this.measurementRepository.listMeasures(stationId);
+    return measures;
   }
 }

--- a/src/application/use-cases/emailStation/RegisterEmailStationUseCase.ts
+++ b/src/application/use-cases/emailStation/RegisterEmailStationUseCase.ts
@@ -9,7 +9,6 @@ export class RegisterEmailStationUseCase {
   }
 
   public async execute(email: string, stationId: string ) {
-    console.log(this.stationRepository);
     
     let station = await this.stationRepository.findById(stationId);
 

--- a/src/application/use-cases/measure/ListMeasureUseCase.ts
+++ b/src/application/use-cases/measure/ListMeasureUseCase.ts
@@ -12,4 +12,10 @@ export class ListMeasureUseCase extends MeasureUseCase {
   ): Promise<ListMeasureResponseDTO[]> {
     return await this.measureRepository.listMeasures(stationId);
   }
+
+  public async executePublic(
+    stationId: string | null
+  ): Promise<ListMeasureResponseDTO[]> {
+    return await this.measureRepository.listWithFilters(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), new Date(), stationId);
+  }
 }

--- a/src/domain/interfaces/repositories/IMeasureRepository.ts
+++ b/src/domain/interfaces/repositories/IMeasureRepository.ts
@@ -12,10 +12,5 @@ export interface IMeasureRepository {
   updateMeasure(measure: Measure): Promise<Measure>;
   listMeasuresLastHour(): Promise<Measure[]>;
   listMeasuresLastDay(): Promise<Measure[]>;
-  listWithFilters(filters: {
-    startDate?: Date;
-    endDate?: Date;
-    stationId?: string;
-    parameterId?: string;
-  }): Promise<Measure[]>;
+  listWithFilters(startDate: Date, endDate: Date, stationId: string): Promise<ListMeasureResponseDTO[]>;
 }

--- a/src/infrastructure/repositories/AlertRepository.ts
+++ b/src/infrastructure/repositories/AlertRepository.ts
@@ -46,7 +46,7 @@ export class AlertRepository implements IAlertRepository {
           measure: {
             id: alert.measure.id,
             unixTime: alert.measure.unixTime,
-            value: alert.measure.value,
+            value: alert.measure.value + " " + alert.measure.parameter.idTypeParameter.unit,
             parameterText: alert.measure.parameter.getParameterName(),
             criticality: alert.type.criticality,
           } as ListMeasureResponseDTO,

--- a/src/web/controllers/Dashboard/ListDashboard.ts
+++ b/src/web/controllers/Dashboard/ListDashboard.ts
@@ -4,53 +4,21 @@ import { ListDashboardUseCase } from '../../../application/use-cases/dashboard/L
 export class ListDashboardController {
   constructor(private listDashboardUseCase: ListDashboardUseCase) {}
 
-  async getAll(req: Request, res, next: NextFunction): Promise<Response> {
+  async handle(req: Request, res, next: NextFunction): Promise<Response> {
     try {
-      const { 
-        startDate, 
-        endDate, 
-        date,
-        stationId, 
-        parameterId,
-        lastDays
-      } = req.query;
+      const { stationId, startDate, endDate } = req.body;
+      const measures = await this.listDashboardUseCase.execute(stationId, startDate, endDate);
+      return res.sendSuccess(measures);
+    } catch (error) {
+      next(error);
+    }
+  }
 
-      let startDateObj: Date | undefined = undefined;
-      let endDateObj: Date | undefined = undefined;
-      
-      if (lastDays) {
-        const days = parseInt(lastDays as string, 10);
-        endDateObj = new Date();
-        startDateObj = new Date();
-        startDateObj.setDate(startDateObj.getDate() - days);
-      }
-      else if (date) {
-        const dateStr = date as string;
-        
-        startDateObj = new Date(`${dateStr}T00:00:00-03:00`);
-        endDateObj = new Date(`${dateStr}T23:59:59.999-03:00`);
-      } 
-      else {
-        if (startDate) {
-          startDateObj = new Date(startDate as string);
-        }
-        
-        if (endDate) {
-          endDateObj = new Date(endDate as string);
-        }
-      }
-
-      const filters = {
-        startDate: startDateObj,
-        endDate: endDateObj,
-        stationId: stationId ? String(stationId) : undefined,
-        parameterId: parameterId ? String(parameterId) : undefined
-      };
-
-      const dashboardData = await this.listDashboardUseCase.execute(filters);
-
-      return res.sendSuccess(dashboardData, 200);
-      
+  async handlePublic(req: Request, res, next: NextFunction): Promise<Response> {
+    try {
+      const { stationId } = req.params;
+      const measures = await this.listDashboardUseCase.execute(stationId, new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), new Date());
+      return res.sendSuccess(measures);
     } catch (error) {
       next(error);
     }

--- a/src/web/controllers/Measure/MeasureController.ts
+++ b/src/web/controllers/Measure/MeasureController.ts
@@ -77,6 +77,19 @@ export class MeasureController {
     }
   }
 
+  async handlePublic(req: Request, res, next: NextFunction): Promise<Response> {
+    try {
+      const stationId: string | null = req.query.stationId
+      ? String(req.query.stationId)
+      : null;
+
+      const measures = await this.listUseCase.executePublic(stationId);
+      return res.sendSuccess(measures, 200);
+    } catch (error) {
+      next(error);
+    }
+  }
+
   async delete(req: Request, res, next: NextFunction): Promise<Response> {
     try {
       const { id } = req.params;

--- a/src/web/dtos/measure/ListMeasureDTO.ts
+++ b/src/web/dtos/measure/ListMeasureDTO.ts
@@ -1,7 +1,7 @@
 export interface ListMeasureResponseDTO {
     id: string;
     unixTime: number;
-    value: number;
+    value: string;
     parameterText: string
   }
   

--- a/src/web/routes/Measure.routes.ts
+++ b/src/web/routes/Measure.routes.ts
@@ -141,6 +141,46 @@ measureRoutes.get('/list', limiter, asyncHandler((req, res, next) => measureCont
 
 /**
  * @swagger
+ * /measure/public/{stationId}:
+ *   get:
+ *     summary: Lista todas as medidas de uma estação
+ *     tags: [Medidas]
+ *     parameters:
+ *       - in: path
+ *         name: stationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID da estação
+ *     responses:
+ *       200:
+ *         description: Lista de medidas retornada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                   value:
+ *                     type: number 
+ *                   parameterId:
+ *                     type: string
+ *                   stationId:
+ *                     type: string
+ *                   createdAt:
+ *                     type: string 
+ *                   parameterText:
+ *                     type: string
+ *                   unixTime:
+ *                     type: number
+ */
+measureRoutes.get('/public/', limiter, asyncHandler((req, res, next) => measureController.handlePublic(req, res, next)));
+
+/**
+ * @swagger
  * /measure/read/{id}:
  *   get:
  *     summary: Obtém uma medida específica

--- a/src/web/routes/dashboard.routes.ts
+++ b/src/web/routes/dashboard.routes.ts
@@ -18,96 +18,12 @@ const listDashboardUseCase = new ListDashboardUseCase(
 
 const listDashboardController = new ListDashboardController(listDashboardUseCase);
 
-/**
- * @swagger
- * /dashboard/public:
- *   get:
- *     summary: Obtém dados públicos do dashboard (últimos 7 dias)
- *     tags: [Dashboard]
- *     responses:
- *       200:
- *         description: Dados do dashboard retornados com sucesso
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 stations:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       id:
- *                         type: string
- *                       name:
- *                         type: string
- *                       measures:
- *                         type: array
- *                         items:
- *                           type: object
- *                           properties:
- *                             parameterId:
- *                               type: string
- *                             value:
- *                               type: number
- *                             timestamp:
- *                               type: string
- *                               format: date-time
- */
-dashboardRoutes.get('/public', limiter, asyncHandler((req, res, next) => {
-    req.query.lastDays = '7';
-    return listDashboardController.getAll(req, res, next);
+dashboardRoutes.get('/:stationId/', limiter, ensureAuthenticated, asyncHandler((req, res, next) => {
+    return listDashboardController.handle(req, res, next);
 }));
 
-/**
- * @swagger
- * /dashboard/list:
- *   get:
- *     summary: Obtém dados do dashboard (requer autenticação)
- *     tags: [Dashboard]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: query
- *         name: lastDays
- *         schema:
- *           type: string
- *         description: Número de dias para buscar os dados
- *         example: 7
- *     responses:
- *       200:
- *         description: Dados do dashboard retornados com sucesso
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 stations:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       id:
- *                         type: string
- *                       name:
- *                         type: string
- *                       measures:
- *                         type: array
- *                         items:
- *                           type: object
- *                           properties:
- *                             parameterId:
- *                               type: string
- *                             value:
- *                               type: number
- *                             timestamp:
- *                               type: string
- *                               format: date-time
- *       401:
- *         description: Não autorizado
- */
-dashboardRoutes.get('/list', limiter, ensureAuthenticated, asyncHandler((req, res, next) => 
-    listDashboardController.getAll(req, res, next)
-));
+dashboardRoutes.get('/public/:stationId', limiter, asyncHandler((req, res, next) => {
+    return listDashboardController.handlePublic(req, res, next);
+}));
 
 export { dashboardRoutes };


### PR DESCRIPTION
# Arrumar endpoint do dashboard para usar com novo grafico

## Branch
- refactor/A20-154/arrumar-endpoint-do-dashboard

## Changelog:
- Arrumei os dtos para mandar os dados de acordo com as necessidades
- coloquei para o usuario comum poder filtrar apenas dados de 7 dias
- usuarios logados puxam todos os dados

## Como Testar:
- Rode o backend e o front e acesse a pagina de dashboard

## Dependências:
- npm i